### PR TITLE
Make Logger compatible with logrus.FieldLogger

### DIFF
--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 // topics to log info and errors.
 type Logger interface {
 	Infof(format string, v ...interface{})
-	Error(format string, v ...interface{})
+	Errorf(format string, v ...interface{})
 }
 
 // Server allows to create topics that clients can subscribe to.
@@ -68,4 +68,4 @@ type voidLogger struct {
 
 func (l voidLogger) Infof(format string, v ...interface{}) {}
 
-func (l voidLogger) Error(format string, v ...interface{}) {}
+func (l voidLogger) Errorf(format string, v ...interface{}) {}

--- a/topic.go
+++ b/topic.go
@@ -121,7 +121,7 @@ func (t *Topic) sendMsg(subscribers []*Subscriber, msg interface{}) {
 func (t *Topic) sendMsgToSubscriber(s *Subscriber, msg interface{}, wg *sync.WaitGroup) {
 	err := s.SendMessage(msg)
 	if err != nil {
-		t.l.Error("error sending message to the client %s:%+v", s.ID, err)
+		t.l.Errorf("error sending message to the client %s:%+v", s.ID, err)
 		s.Close()
 	}
 	wg.Done()


### PR DESCRIPTION
In `gowse` the `Logger` interface is defined as:
```
type Logger interface {
    Infof(format string, v ...interface{})
    Error(format string, v ...interface{})
}
```
Whereas in `logrus`, the `FieldLogger` interface is defined as:
```
type FieldLogger interface {
...
    Infof(format string, args ...interface{})
...
    Errorf(format string, args ...interface{})
...
    Error(args ...interface{})
...
}
```

Which makes the `logrus` type incompatible for passing it to `NewServer`. 

However, replacing the `Error` method for `Errorf` in the `Logger` interface that `gowse` uses resolves the issue by providing a practically equivalent method for logging errors which is also equivalent in `logrus`.